### PR TITLE
Cmake integrability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(fire)
 
+option(FIRE_EXAMPLES "Compile examples" ON)
+option(FIRE_UNIT_TESTS "Enable unit tests" ON)
+
 if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 11)
 endif()
@@ -20,5 +23,16 @@ if(NOT DEFINED DISABLE_PEDANTIC)
 endif()
 set(ignoreMe "${DISABLE_PEDANTIC}")
 
-add_subdirectory(examples)
-add_subdirectory(tests)
+# Disable examples and test if fire is a sub-project
+if (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(FIRE_EXAMPLES FALSE)
+    set(FIRE_UNIT_TESTS FALSE)
+endif()
+
+if (FIRE_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+if (FIRE_UNIT_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ if(NOT DEFINED DISABLE_PEDANTIC)
 endif()
 set(ignoreMe "${DISABLE_PEDANTIC}")
 
+# Setup Fire to be used in 3rd party project using exports. Create a fire target
+add_library(fire INTERFACE)
+target_include_directories(fire INTERFACE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>")
+
 # Disable examples and test if fire is a sub-project
 if (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(FIRE_EXAMPLES FALSE)

--- a/README.md
+++ b/README.md
@@ -180,6 +180,41 @@ A method for getting all positional arguments (requires [no space assignment mod
     * CLI usage: `program abc xyz` -> `params=={"abc", "xyz"}`
     * CLI usage: `program` -> `params=={}`
 
+## CMake integration
+
+Fire can easily be used by other C++ CMake projects.
+
+You may use Fire from a folder in your project (typically a git submodule).
+
+```
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(foo)
+set(CMAKE_CXX_STANDARD 11)
+
+add_subdirectory(fire_folder)
+
+add_executable(bar bar.cpp)
+target_link_libraries(bar fire)
+```
+
+Alternatively, you can also use the more modern FetchContent.
+
+```
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+project(foo)
+set(CMAKE_CXX_STANDARD 11)
+
+include(FetchContent)
+FetchContent_Declare(
+  fire
+  GIT_REPOSITORY https://github.com/kongaskristjan/fire-hpp
+)
+FetchContent_MakeAvailable(fire)
+
+add_executable(bar bar.cpp)
+target_link_libraries(bar fire)
+```
+
 ## Development
 
 This library uses extensive testing. Unit tests are located in `tests/`, while `examples/` are used as integration tests. The latter also ensures examples are up-to-date. Before committing, please verify `python3 ./build/tests/run_standard_tests.py` succeed.


### PR DESCRIPTION
Improve the integrability in other CMake projects by exporting a fire target and disabling the compilation of tests and examples if included as sub-project.