### PR TITLE
Added CMake install commands and a local conanfile.py.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(fire-hpp)
 
+include(GNUInstallDirs)
+
 option(FIRE_EXAMPLES "Compile examples" ON)
 option(FIRE_UNIT_TESTS "Enable unit tests" ON)
 
@@ -25,10 +27,29 @@ set(ignoreMe "${DISABLE_PEDANTIC}")
 
 # Setup Fire to be used in 3rd party project using exports. Create a fire target
 add_library(fire-hpp INTERFACE)
-target_include_directories(fire-hpp INTERFACE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>/include")
+target_compile_features(fire-hpp INTERFACE cxx_std_11)
+target_include_directories(fire-hpp INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-# Disable examples and test if fire is a sub-project
-if (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(TARGETS fire-hpp EXPORT fire-hpp-targets)
+install(EXPORT fire-hpp-targets
+    FILE fire-hpp-config.cmake
+    NAMESPACE fire-hpp::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fire-hpp)
+
+# check if we're included as a subproject (i.e. through add_subdirectory()
+get_directory_property(IS_SUBPROJECT PARENT_DIRECTORY)
+if (IS_SUBPROJECT)
+    message(STATUS "fire-hpp included as a subproject.")
+    # add export alias to mirror find_package()-exported target
+    if (NOT TARGET fire-hpp::fire-hpp)
+        message(STATUS "Adding 'fire-hpp::fire-hpp' export alias.")
+        add_library(fire-hpp::fire-hpp ALIAS fire-hpp)
+    endif()
+
+    # Disable tests and examples
     set(FIRE_EXAMPLES FALSE)
     set(FIRE_UNIT_TESTS FALSE)
 endif()

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ set(CMAKE_CXX_STANDARD 11)
 add_subdirectory(fire_folder)
 
 add_executable(bar bar.cpp)
-target_link_libraries(bar fire)
+target_link_libraries(bar fire-hpp::fire-hpp)
 ```
 
 Alternatively, you can also use the more modern FetchContent.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,22 @@ add_executable(bar bar.cpp)
 target_link_libraries(bar fire)
 ```
 
+Fire can also be installed and found through `find_package()`:
+
+```
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(foo)
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(fire-hpp REQUIRED)
+add_executable(bar bar.cpp)
+target_link_libraries(bar fire-hpp::fire-hpp)
+```
+
+## Conan integration
+
+Fire can be packaged for consumption through Conan by running `conan create . fire-hpp/version@user/channel` from the root directory of this repository. It can then be consumed as in the `find_package()` example above if using `cmake_find_package` generator.
+
 ## Development
 
 This library uses extensive testing. Unit tests are located in `tests/`, while `examples/` are used as integration tests. The latter also ensures examples are up-to-date. Before committing, please verify `python3 ./build/tests/run_standard_tests.py` succeed.

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,37 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class FireHppConan(ConanFile):
+    name = "fire-hpp"
+    homepage = "https://github.com/kongaskristjan/fire-hpp"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Fire for C++: Create fully functional CLIs using function signatures"
+    topics = ("command-line", "argument", "parser")
+    license = "BSL-1.0"
+    no_copy_source = True
+    exports_sources = ["CMakeLists.txt", "include/*"]
+    settings = "os", "arch", "compiler", "build_type"
+
+    _build_subfolder = "build_subfolder"
+    _cmake = None
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["FIRE_EXAMPLES"] = False
+        self._cmake.definitions["FIRE_UNIT_TESTS"] = False
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib"))
+
+    def package_id(self):
+        self.info.header_only()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ if(${CMAKE_VERSION} VERSION_GREATER "3.11.0")
     FetchContent_GetProperties(googletest)
     if(NOT googletest_POPULATED)
         FetchContent_Populate(googletest)
-        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
     endif()
 
     add_executable(run_tests tests.cpp)


### PR DESCRIPTION
Added install commands for `fire.hpp` into `CMakeLists.txt`. It's not super likely people will `make install` a single-header lib onto their system, but they might need to install to some prefix as part of a superbuild or something, I dunno. The real reason for my adding it though is to better support package managers. Having the library provide a suggested install layout helps keep deployments uniform since the recipe author doesn't need to manually copy files and decide on a layout of their own. It also makes, say, migrating from one package manager to another easier if everyone just uses the suggested layout and you don't need to fix header paths to do so. (Speaking from experience, this sucks.)

Which, speaking of, I also included a `conanfile.py` which installs the checked out copy as a Conan package. I'm sure someone will find that handy.

PS: This all came about because I use Conan for my package management and wanted to submit a package recipe for this library to conan-center, and having the install instructions in the library instead of in the package recipe is good for the C++ ecosystem for the aforementioned reasons. I could just release/package off my fork, but that didn't really seem right, so I figured I'd rather try to push these changes upstream.